### PR TITLE
gitignore: ignore antipattern files and folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,29 @@
 docs/test-plan/
 dist-newstyle
 
+# Dockerfiles, or docker-compose files are not how we build or deploy software.
+# Only Nix expressions are allowed.
+*Dockerfile*
+*docker-compose*
+
+# Github Workflows are not what we use to perform CI, we use Hercules-CI
+# instead.
+.github/workflows
+
+# There's a habit of putting random shell scripts into a folder named 'bin' or
+# 'ci' at the root of the Git repo. Shell scripts should, in most cases, not
+# exist in this repository.  Scripts should be encoded via nix, by being added
+# to the `apps` attribute of the flake.nix, and ran via `nix run`.  This way,
+# they work every single time and do not depend on the environment where they
+# are ran, or require the user to install any additional dependencies.
+bin
+ci
+
+# Editor Settings and more should not be added as files to root of the repo,
+# outside of Nix. Using Nix, you can provide a custom vscodium/vscode binary
+# which uses a specified config.
+.vscode
+
+# Prevents Nix results from `nix build`, etc, from being checked in
+# accidentally.
+*result*


### PR DESCRIPTION
This adds a bunch of paths to our `.gitignore` that will prevent some anti-patterns from emerging, along with explanations for why, inside the file. Prior to a monorepo, this would have required adding this `.gitignore` to every single repo, and keeping it up to date. But now that we're in a monorepo, it is feasible to maintain.