### PR TITLE
perSystem -> forAllSystems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
       supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
 
       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
-      perSystem = nixpkgs.lib.genAttrs supportedSystems;
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
 
       # Nixpkgs instantiated for supported system types.
       nixpkgsFor = system:
@@ -99,23 +99,23 @@
           systems = [ "x86_64-linux" ];
         };
 
-        project = perSystem projectFor;
-        flake = perSystem (system: (projectFor system).flake { });
+        project = forAllSystems projectFor;
+        flake = forAllSystems (system: (projectFor system).flake { });
 
         # this could be done automatically, but would reduce readability
-        packages = perSystem (system: self.flake.${system}.packages);
-        checks = perSystem (system: self.flake.${system}.checks);
-        check = perSystem (
+        packages = forAllSystems (system: self.flake.${system}.packages);
+        checks = forAllSystems (system: self.flake.${system}.checks);
+        check = forAllSystems (
           system:
             (nixpkgsFor system).runCommand "combined-test" {
               nativeBuildInputs = builtins.attrValues self.checks.${system};
             } "touch $out"
         );
 
-        devShell = perSystem (system: self.flake.${system}.devShell);
+        devShell = forAllSystems (system: self.flake.${system}.devShell);
 
-        apps = perSystem (system: let
-          pkgs = (perSystem nixpkgsFor)."${system}";
+        apps = forAllSystems (system: let
+          pkgs = (forAllSystems nixpkgsFor)."${system}";
         in
           {
             feedback-loop = {


### PR DESCRIPTION
There is no reason other than obscurity to change the name of this simple boiler plate function from Eelco's hello-world example. https://github.com/NixOS/templates/blob/d7c2d8cd20d72a8d537cc6443b75cd980880f9f0/c-hello/flake.nix#L17