### PR TITLE
updating flake to support updated CI_Integration

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -1,3 +1,0 @@
-if builtins?getFlake
-then (builtins.getFlake (toString ./.)).ciNix
-else (import ./flake-compat.nix).defaultNix.ciNix

--- a/flake-compat.nix
+++ b/flake-compat.nix
@@ -1,9 +1,0 @@
-let
-  lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-  inherit (lock.nodes.flake-compat.locked) owner repo rev narHash;
-  flake-compat = builtins.fetchTarball {
-    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
-    sha256 = narHash;
-  };
-in
-import flake-compat { src = ./.; }

--- a/flake.lock
+++ b/flake.lock
@@ -99,88 +99,6 @@
         "type": "github"
       }
     },
-    "danalib": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-compat-ci": "flake-compat-ci",
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1646800070,
-        "narHash": "sha256-L0lIKU1lc4PTyrUOH0mDc+NHe4DGxhwxmnTdexypKN4=",
-        "owner": "ardanalabs",
-        "repo": "danalib",
-        "rev": "36498e9fc64ed7e879f067dd0c0e5497a525f8e5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ardanalabs",
-        "repo": "danalib",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat-ci": {
-      "locked": {
-        "lastModified": 1646664117,
-        "narHash": "sha256-AX2VewPcS9eRsoirVHfnk07MHAOH6CTDiD10XtRaZbk=",
-        "owner": "hercules-ci",
-        "repo": "flake-compat-ci",
-        "rev": "e588637b2eec4261ed0d36335c83a117f2744dea",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-compat-ci",
-        "type": "github"
-      }
-    },
-    "flake-compat-ci_2": {
-      "locked": {
-        "lastModified": 1646664117,
-        "narHash": "sha256-AX2VewPcS9eRsoirVHfnk07MHAOH6CTDiD10XtRaZbk=",
-        "owner": "hercules-ci",
-        "repo": "flake-compat-ci",
-        "rev": "e588637b2eec4261ed0d36335c83a117f2744dea",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-compat-ci",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "locked": {
         "lastModified": 1644229661,
@@ -380,17 +298,18 @@
       }
     },
     "nixpkgs": {
+      "flake": false,
       "locked": {
-        "lastModified": 1639161226,
-        "narHash": "sha256-75Y08ynJDTq6HHGIF+8IADBJSVip0UyWQH7jqSFnRR8=",
-        "owner": "nixos",
+        "lastModified": 1645493675,
+        "narHash": "sha256-9xundbZQbhFodsQRh6QMN1GeSXfo3y/5NL0CZcJULz0=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "573095944e7c1d58d30fc679c81af63668b54056",
+        "rev": "74b10859829153d5c5d50f7c77b86763759e8654",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-21.11",
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -459,23 +378,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645493675,
-        "narHash": "sha256-9xundbZQbhFodsQRh6QMN1GeSXfo3y/5NL0CZcJULz0=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "74b10859829153d5c5d50f7c77b86763759e8654",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "old-ghc-nix": {
       "flake": false,
       "locked": {
@@ -501,7 +403,7 @@
         "haskell-language-server": "haskell-language-server",
         "haskell-nix": "haskell-nix_2",
         "iohk-nix": "iohk-nix",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "pre-commit-hooks-nix": "pre-commit-hooks-nix",
         "sphinxcontrib-haddock": "sphinxcontrib-haddock",
         "stackage-nix": "stackage-nix"
@@ -538,9 +440,6 @@
     },
     "root": {
       "inputs": {
-        "danalib": "danalib",
-        "flake-compat": "flake-compat_2",
-        "flake-compat-ci": "flake-compat-ci_2",
         "haskell-nix": "haskell-nix",
         "nixpkgs": [
           "haskell-nix",

--- a/flake.nix
+++ b/flake.nix
@@ -1,17 +1,11 @@
 {
   description = "dUSD";
   inputs = {
-    danalib.url = "github:ardanalabs/danalib";
     haskell-nix.url = "github:input-output-hk/haskell.nix";
     nixpkgs.follows = "haskell-nix/nixpkgs-unstable";
     haskell-nix.inputs.nixpkgs.follows = "haskell-nix/nixpkgs-2105";
     plutus.url = "github:input-output-hk/plutus";
-    # used for libsodium-vrf
-    flake-compat-ci.url = "github:hercules-ci/flake-compat-ci";
-    flake-compat = {
-      url = "github:edolstra/flake-compat";
-      flake = false;
-    };
+    #   used for libsodium-vrf
   };
   outputs =
     {
@@ -19,14 +13,11 @@
       nixpkgs,
       haskell-nix,
       plutus,
-      flake-compat,
-      flake-compat-ci,
-      danalib,
     }
     @ inputs:
     let
       # System types to support.
-      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+      supportedSystems = [ "x86_64-linux" ]; #"aarch64-linux" ];
 
       # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
@@ -101,11 +92,6 @@
         };
     in
       {
-        ciNix = flake-compat-ci.lib.recurseIntoFlakeWith {
-          flake = self;
-          systems = [ "x86_64-linux" ];
-        };
-
         project = forAllSystems projectFor;
         flake = forAllSystems (system: (projectFor system).flake { });
 
@@ -136,7 +122,7 @@
         );
 
         devShell = forAllSystems (system: self.flake.${system}.devShell);
-
+        defaultPackage = forAllSystems (system: self.packages.${system}."dUSD:test:tests");
         apps = forAllSystems (system: let
           pkgs = (forAllSystems nixpkgsFor)."${system}";
         in


### PR DESCRIPTION
As our instance of Hercules has been updated, we no longer require the ci-compat shim to build using flakes.
Given native support of our functional pipeline, I am removing the ci-compat throughout our repositories.