### PR TITLE
Re-enable HLS support for 2-devshells

### DIFF
--- a/offchain/hie.yaml
+++ b/offchain/hie.yaml
@@ -1,0 +1,2 @@
+cradle:
+  cabal:

--- a/onchain/hie.yaml
+++ b/onchain/hie.yaml
@@ -1,0 +1,2 @@
+cradle:
+  cabal:


### PR DESCRIPTION
When using two projects in a monorepo, the HLS configuration (`hie.yaml`) must exist in their respective project roots.