### PR TITLE
[WIP/demo] flake: add dUSD-lint to devShell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -304,16 +304,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1648667273,
-        "narHash": "sha256-eQUb40xDyv0Ye3oMzGz6tcHPF9y9Xhq1QksV9h7uEDk=",
-        "ref": "spec-type",
-        "rev": "4648a98d91f754ae0f7a3d035a1aaa871eb1b4fc",
-        "revCount": 34,
+        "lastModified": 1650427214,
+        "narHash": "sha256-9m66rRSSM614ocRXNPAArwnrS6zzCQYYhd3nw8g4QUg=",
+        "ref": "overengineered",
+        "rev": "5555def5a25c5437834c06cbe79b3945916ec59f",
+        "revCount": 28,
         "type": "git",
         "url": "https://gitlab.homotopic.tech/nix/lint-utils.git"
       },
       "original": {
-        "ref": "spec-type",
+        "ref": "overengineered",
         "type": "git",
         "url": "https://gitlab.homotopic.tech/nix/lint-utils.git"
       }


### PR DESCRIPTION
This adds a concatenation of our current devShell with one from lint-utils via the function `mkConcatShellWithNamePrefix`

This means you can do `nix develop` and you will have a shell script named `dUSD-lint` on your path ready to execute, instead of running `nix run .#format`.

This is arguably the worst Nix code I have ever written, and it was done in response to https://github.com/ArdanaLabs/dUSD/issues/59.

I hope this proves a point about waiting for upstream changes in libraries, instead of moving ahead too fast and not thinking hard enough about the consequences of using a fork/undecided feature-branch. 

**This PR technical debt. Merge at own risk.**

 