### PR TITLE
nix: Use available branch of lint-utils

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1477,16 +1477,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1648667273,
-        "narHash": "sha256-eQUb40xDyv0Ye3oMzGz6tcHPF9y9Xhq1QksV9h7uEDk=",
-        "ref": "spec-type",
-        "rev": "4648a98d91f754ae0f7a3d035a1aaa871eb1b4fc",
-        "revCount": 34,
+        "lastModified": 1650427214,
+        "narHash": "sha256-9m66rRSSM614ocRXNPAArwnrS6zzCQYYhd3nw8g4QUg=",
+        "ref": "overengineered",
+        "rev": "5555def5a25c5437834c06cbe79b3945916ec59f",
+        "revCount": 28,
         "type": "git",
         "url": "https://gitlab.homotopic.tech/nix/lint-utils.git"
       },
       "original": {
-        "ref": "spec-type",
+        "ref": "overengineered",
         "type": "git",
         "url": "https://gitlab.homotopic.tech/nix/lint-utils.git"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     lint-utils = {
       type = "git";
       url = "https://gitlab.homotopic.tech/nix/lint-utils.git";
-      ref = "spec-type";
+      ref = "overengineered";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
The `spec-type` branch doesn't exist anymore, because it got deleted accidentally. The code now lives in `overengineered` (which is expected to be cleaned up and merged to `master` later).