### PR TITLE
Remove minor syntax error from flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -339,7 +339,7 @@
               self.commonTools.${system} //
               self.offchainTools.${system}
             );
-            shellHook = oa.shellHook + ''$
+            shellHook = oa.shellHook + ''
               ${self.flakeRoot.shellHook}
               # running local cluster + PAB
               export SHELLEY_TEST_DATA="${plutus-apps}/plutus-pab/local-cluster/cluster-data/cardano-node-shelley/"


### PR DESCRIPTION
#96 introduced a minor syntax error in the offchain shell:

```
$ nix develop .#offchain
$: command not found
```

This removes that.