### PR TITLE
`CODEOWNERS`: Use `@ArdanaLabs/devops`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 /.github/CODEOWNERS @CSVdB @delicious-lemon
 
 # Any nix code
-*.nix @MatthewCroughan @nixinator @DarthPJB @srid @delicious-lemon
+*.nix @ArdanaLabs/devops @srid @delicious-lemon
 
 # Monorepo projects
 offchain/hello-world-ui/* @toastal


### PR DESCRIPTION
The Nix reviewers remain the same ... however, now we use the team alias (instead of a hardcoded list of members) - to obviate having to change this file in future when DevOps membership changes.