### PR TITLE
CODEOWNERS: notify srid/delicious-lemon on all onchain nix code changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,8 +11,10 @@
 # This file
 /.github/CODEOWNERS @CSVdB @delicious-lemon
 
-# Any nix code
-*.nix @ArdanaLabs/devops @srid @delicious-lemon
+*.nix @ArdanaLabs/devops
+
+# onchain nix code
+onchain/*.nix @srid @delicious-lemon
 
 # Monorepo projects
 offchain/hello-world-ui/* @toastal


### PR DESCRIPTION
I don't think it's right that we should be notifying srid/delicious-lemon on **all** nix code changes in this monorepo, especially since we now have proper segmentation of the codebases thanks to https://github.com/ArdanaLabs/dUSD/pull/119 