### PR TITLE
gitignore: ban flake.nix below the root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ ci
 
 # Ignore direnv cache
 .direnv
+
+# Ignore flake.nix anywhere except for the root
+flake.nix
+!/flake.nix


### PR DESCRIPTION
Subflakes are not a concept in Nix yet, I am working upstream to get that fixed. But in the meantime, we need to ban flake.nix from being added anywhere, to prevent developers from creating dead Nix code that isn't added to the project, in isolation.