### PR TITLE
treewide: use default.nix to manage imports of flake-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ nix flake check -L
 
 ### Making a new package (flake module)
 
+Every project is imported by the top-level default.nix in each folder. For
+example, `offchain/default.nix` imports the flake-module.nix for multiple
+projects.
+
 Each project in this repository should have a `flake-module.nix` based on the
 following template, at its root. You can run `nix flake init -t .`
 anywhere in this repository, and a new `flake-module.nix` with the following

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ./flake-module.nix
+  ];
+}

--- a/flake.nix
+++ b/flake.nix
@@ -35,13 +35,10 @@
       {
         systems = [ "x86_64-linux" ];
         imports = [
-          ./offchain/flake-module.nix
-          ./offchain/hello-world-ui/flake-module.nix
-          ./onchain/flake-module.nix
-          ./docs/flake-module.nix
-          ./nix/flake-modules/format/flake-module.nix
-          ./nix/flake-modules/haskell.nix/flake-module.nix
-          ./nix/flake-modules/templates/flake-module.nix
+          ./offchain
+          ./onchain
+          ./docs
+          ./nix/flake-modules
         ];
       }
     ).config.flake;

--- a/nix/flake-modules/default.nix
+++ b/nix/flake-modules/default.nix
@@ -1,0 +1,7 @@
+{
+  imports = [
+    ./haskell.nix/flake-module.nix
+    ./format/flake-module.nix
+    ./templates/flake-module.nix
+  ];
+}

--- a/offchain/default.nix
+++ b/offchain/default.nix
@@ -1,0 +1,6 @@
+{
+  imports = [
+    ./flake-module.nix
+    ./hello-world-ui/flake-module.nix
+  ];
+}

--- a/onchain/default.nix
+++ b/onchain/default.nix
@@ -1,0 +1,5 @@
+{
+  imports = [
+    ./flake-module.nix
+  ];
+}


### PR DESCRIPTION
Prior to this, the top-level flake.nix had to be appended to for every single project. This changes the structure to give each project its own top-level default.nix which imports other projects. For example, offchain/default.nix now imports hello-world and hello-world-ui, instead of the flake.nix doing this.