### PR TITLE
hello-world-ui: remove seemingly unnecessary inputsFrom arg

### DIFF
--- a/offchain/hello-world-ui/flake-module.nix
+++ b/offchain/hello-world-ui/flake-module.nix
@@ -69,7 +69,6 @@
       };
       devShells.${projectName} = pkgs.mkShell {
         name = projectName;
-        inputsFrom = builtins.attrValues self'.packages;
         buildInputs = (with pkgs; [
           nodejs-16_x
           (ps.command {})


### PR DESCRIPTION
This causes problems with laziness and evaluation time in the devShell, and it's not clear why the argument is needed in the first place