### PR TITLE
build(nix): update flake parts, fix flake-module.nix files

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ skeleton template will be created in your current directory.
 ```
 { self, ... }:
 {
-  perSystem = system: { config, self', inputs', ... }: {
+  perSystem = { config, self', inputs', system, ... }: {
   };
   flake = {
   };
@@ -86,7 +86,7 @@ skeleton template will be created in your current directory.
 ```
 
 This is part of the
-[flake-modules-core](https://github.com/hercules-ci/flake-modules-core)
+[flake-parts](https://github.com/hercules-ci/flake-parts)
 framework. Each of these `flake-module.nix` files can be thought of as a
 subflake. They can also be thought of as a `default.nix` similar to what you see
 in Nixpkgs next to every package. The real name for this, though, is a "flake

--- a/docs/flake-module.nix
+++ b/docs/flake-module.nix
@@ -1,6 +1,6 @@
 { self, ... }:
 {
-  perSystem = system: { config, self', inputs', ... }:
+  perSystem = { config, self', inputs', system, ... }:
     let
       pkgs = inputs'.nixpkgs.legacyPackages;
     in

--- a/flake.lock
+++ b/flake.lock
@@ -1536,23 +1536,23 @@
         "type": "github"
       }
     },
-    "flake-modules-core": {
+    "flake-parts": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1652600765,
-        "narHash": "sha256-p69zfGnl53euO1kI9yki2FN+Q5a8pv0b/pVnmDMMlt8=",
+        "lastModified": 1657102481,
+        "narHash": "sha256-62Fuw8JgPub38OdgNefkIKOodM9nC3M0AG6lS+7smf4=",
         "owner": "hercules-ci",
-        "repo": "flake-modules-core",
-        "rev": "022938a1deb3f9496b7f19f463ed2c3348ca4d3b",
+        "repo": "flake-parts",
+        "rev": "608ed3502263d6f4f886d75c48fc2b444a4ab8d8",
         "type": "github"
       },
       "original": {
         "owner": "hercules-ci",
-        "repo": "flake-modules-core",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -4911,7 +4911,7 @@
         "cardano-node": "cardano-node",
         "cardano-transaction-lib": "cardano-transaction-lib",
         "dream2nix": "dream2nix",
-        "flake-modules-core": "flake-modules-core",
+        "flake-parts": "flake-parts",
         "haskell-nix": "haskell-nix_3",
         "lint-utils": "lint-utils",
         "nixpkgs": "nixpkgs_8",

--- a/flake.nix
+++ b/flake.nix
@@ -15,8 +15,8 @@
       ref = "overengineered";
       inputs.nixpkgs.follows = "nixpkgs";
     };
-    flake-modules-core = {
-      url = "github:hercules-ci/flake-modules-core";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     dream2nix = {
@@ -31,8 +31,8 @@
     purs-nix-0-14.url = "github:ursi/purs-nix/ps-0.14";
   };
 
-  outputs = { self, flake-modules-core, ... }:
-    (flake-modules-core.lib.evalFlakeModule
+  outputs = { self, flake-parts, ... }:
+    (flake-parts.lib.evalFlakeModule
       { inherit self; }
       {
         systems = [ "x86_64-linux" ];

--- a/nix/flake-modules/format/flake-module.nix
+++ b/nix/flake-modules/format/flake-module.nix
@@ -1,6 +1,6 @@
 { self, ... }:
 {
-  perSystem = system: { config, self', inputs', ... }:
+  perSystem = { config, self', inputs', system, ... }:
     let
       # TODO: We should be able to get rid of this once
       # https://github.com/numtide/treefmt/issues/165 is implemented upstream.

--- a/nix/flake-modules/haskell.nix/flake-module.nix
+++ b/nix/flake-modules/haskell.nix/flake-module.nix
@@ -6,7 +6,7 @@ let
     ;
 in
 {
-  perSystem = system: { config, self', inputs', ... }: {
+  perSystem = { config, self', inputs', system, ... }: {
     options = {
       haskell-nix = {
         pkgs = mkOption {

--- a/nix/flake-modules/templates/flake-module-skeleton/flake-module.nix
+++ b/nix/flake-modules/templates/flake-module-skeleton/flake-module.nix
@@ -1,5 +1,5 @@
 { self, ... }:
 {
-  perSystem = system: { config, self', inputs', ... }: { };
+  perSystem = { config, self', inputs', system, ... }: { };
   flake = { };
 }

--- a/offchain-ctl/flake-module.nix
+++ b/offchain-ctl/flake-module.nix
@@ -1,6 +1,6 @@
 { self, ... }:
 {
-  perSystem = system: { config, self', inputs', ... }:
+  perSystem = { config, self', inputs', system, ... }:
     let
       pkgs = inputs'.nixpkgs.legacyPackages;
       projectName = "hello-world";

--- a/offchain-ctl/hello-world-browser/test/integration/flake-module.nix
+++ b/offchain-ctl/hello-world-browser/test/integration/flake-module.nix
@@ -1,7 +1,7 @@
 # test for dUSD Hello World Browser
 { self, ... }:
 {
-  perSystem = system: { config, self', inputs', ... }:
+  perSystem = { config, self', inputs', system, ... }:
     let
       # dusd-lib contains helper functions for dealing with haskell.nix. From it,
       # we inherit fixHaskellDotNix

--- a/offchain/flake-module.nix
+++ b/offchain/flake-module.nix
@@ -1,6 +1,6 @@
 { self, ... }:
 {
-  perSystem = system: { config, self', inputs', ... }:
+  perSystem = { config, self', inputs', system, ... }:
     let
       # A flake-module in nix/flake-modules/haskell.nix defines haskell-nix
       # packages once, so we can reuse it here, it's more performant.

--- a/offchain/hello-world-ui/flake-module.nix
+++ b/offchain/hello-world-ui/flake-module.nix
@@ -1,7 +1,7 @@
 { self, ... }:
 {
   imports = [ ./test/selenium/flake-module.nix ];
-  perSystem = system: { config, self', inputs', ... }:
+  perSystem = { config, self', inputs', system, ... }:
     let
       pkgs = inputs'.nixpkgs.legacyPackages;
       projectName = "hello-world-ui";

--- a/offchain/hello-world-ui/test/selenium/flake-module.nix
+++ b/offchain/hello-world-ui/test/selenium/flake-module.nix
@@ -1,6 +1,6 @@
 { self, ... }:
 {
-  perSystem = system: { config, self', inputs', ... }:
+  perSystem = { config, self', inputs', system, ... }:
     let
       description = "Selenium test for dUSD Hello World UI";
       # dusd-lib contains helper functions for dealing with haskell.nix. From it,

--- a/onchain/flake-module.nix
+++ b/onchain/flake-module.nix
@@ -1,6 +1,6 @@
 { self, ... }:
 {
-  perSystem = system: { config, self', inputs', ... }:
+  perSystem = { config, self', inputs', system, ... }:
     let
       # A flake-module in nix/flake-modules/haskell.nix defines haskell-nix
       # packages once, so we can reuse it here, it's more performant.


### PR DESCRIPTION
Updates `flake-parts` framework (was renamed from `flake-modules-core`), and fixes the breaking changes. This is so that we don't accumulate more breaking changes in the future as the changes look important.